### PR TITLE
menterじゃなくてmentorだったてへぺろ

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -20,7 +20,7 @@
         Products
       </div>
     </router-link>
-    <router-link to="/admin" class="mobile-hidden" v-if="userRole === 'menter'">
+    <router-link to="/admin" class="mobile-hidden" v-if="userRole === 'mentor'">
       <div class="header-component">
         受講生認証
       </div>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -57,7 +57,7 @@ const routes = [
     component: Admin,
     beforeEnter: (to, from, next) => {
       if (
-        store.state.publicUser.role === "menter" ||
+        store.state.publicUser.role === "mentor" ||
         store.state.publicUser.role === "manager"
       ) {
         next();


### PR DESCRIPTION
menterじゃなくてmentorだった。スペルミス。